### PR TITLE
possible typo

### DIFF
--- a/app/views/post.py
+++ b/app/views/post.py
@@ -60,7 +60,7 @@ def edit(post_id):
             return redirect(url_for('index'))
     else:
         # The post has not been found
-        return render_template("blog/blog_page_404", post_id=post_id)
+        return render_template("blog/blog_page_404.html", post_id=post_id)
 
 @app.route("/delete/<int:post_id>")
 def delete(post_id):


### PR DESCRIPTION
Hi there,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for unescaped Jinja templates. 

In app/views/post.py:63, you're calling `render_template()` with a template file that doesn't end with `.html`, `.htm`, `.xml`, or `.xhtml` extension. Jinja only auto-escapes files with those extensions, so I first thought this could lead to a security issue. But looking more carefully, I realized that this is probably a simple typo, hence the PR.

Bento flagged a few other issues including the usage of "bare except" but I left those alone. If you are curious, feel free download and give Bento a try (https://bento.dev)